### PR TITLE
Migrate to centralised live-import CLAUDE.md system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ applicationinsights-agent-*.jar
 */.DS_Store
 
 .env
+.claude/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+## Repo: service-cp-refdata-courthearing-courthouses
+
+Spring Boot service that proxies court house and court room reference data from the CP backend, exposing two separate REST controllers for house and room lookups.
+
+**Pattern**: Stateless proxy
+**Spring Boot version**: 4.0.1 (target 4.0.6+ per upgrade cycle)
+**Implements**: `api-cp-refdata-courthearing-courthouses`
+
+## Infrastructure
+
+| Component | Technology | Purpose |
+|---|---|---|
+| CP Backend | External HTTP | Source of court house/room reference data |
+| docker-compose | App container only | No WireMock in docker-compose — uses `.env` file for local config |
+
+## Source Structure
+
+```
+uk.gov.hmcts.cp/
+  Application.java                          @SpringBootApplication
+  clients/
+    CourtHousesClient                       RestTemplate → CP backend for both house and room lookups
+  config/
+    AppConfig                               @Bean RestTemplate
+    AppPropertiesBackend                    @Value CP_BACKEND_URL
+  controllers/
+    CourtHousesController                   Handles GET /courthouses/{court_id}
+    CourtRoomsController                    Handles GET /courthouses/{court_id}/courtrooms/{court_room_id}
+    GlobalExceptionHandler                  @RestControllerAdvice; maps exceptions to HTTP codes
+    RootController                          Returns 200 on GET /
+  domain/
+    CourtResponse                           Internal DTO mapping backend court house/room response
+  filters/
+    TracingFilter                           Reads/generates X-Correlation-Id; propagates via MDC
+  mappers/
+    CourtHouseMapper                        Maps CourtResponse domain DTO to API response models
+  services/
+    CourtHousesService                      Calls CourtHousesClient for both house and room endpoints
+```
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `CP_BACKEND_URL` | Base URL of the CP backend (court reference data) | `http://localhost` |
+| `CJSCPPUID` | User UUID header on all backend calls | `00000000-0000-0000-0000-000000000000` |
+| `rpe.AppInsightsInstrumentationKey` | Azure Application Insights key | `00000000-0000-0000-0000-000000000000` |
+
+## Repo-Specific Architecture Rules
+
+- **Single client for two controllers**: `CourtHousesClient` handles both `/courthouses` and `/courthouses/{id}/courtrooms` calls — both controllers delegate to `CourtHousesService` which uses the same client.
+- **No WireMock in docker-compose**: This repo uses a `.env` file for local environment configuration rather than WireMock stubs. Configure `CP_BACKEND_URL` to point at a real or mocked backend.
+- **CJSCPPUID header**: `CourtHousesClient` sets `CJSCPPUID` on every backend request.
+
+## Debugging
+
+| Symptom | Cause / Fix |
+|---|---|
+| 404 on court house | Court ID not found in CP backend; check `CP_BACKEND_URL` and data |
+| Missing court rooms in response | `CourtHouseMapper` may not be mapping `courtRooms` list; check mapper and backend response |
+| Connection refused locally | `.env` file missing or `CP_BACKEND_URL` not set; confirm direnv loaded |
+
+## Repo-Specific Notes
+
+- `ci-build-publish.yml` present alongside standard `ci-draft.yml` / `ci-released.yml`.
+- Local dev uses `.env` file (not `.envrc.example`) — ensure `CP_BACKEND_URL` and `CJSCPPUID` are set.
+- No database; fully stateless.


### PR DESCRIPTION
## Commits

```
b86fc99 docs(claude): add repo-specific Claude context
51aaa05 refactor: Bootstrap centralised live-import CLAUDE.md
```

## What changed (latest commit)

| File | Change |
|---|---|
| `CLAUDE.md` (new, committed) | Repo-specific service context: infrastructure (no WireMock — uses `.env` file for local config), source structure (single CourtHousesClient for both house and room endpoints, CourtHousesController + CourtRoomsController as separate controllers, CourtHouseMapper, TracingFilter), environment variables (CP_BACKEND_URL, CJSCPPUID, AppInsights), architecture rules (one client handles two controllers, .env-based local config, mandatory CJSCPPUID header), debugging guidance |

## Diff summary (latest commit)

```
1 file changed, 67 insertions(+)
  CLAUDE.md | 67 +++++++++++++++++++++++++++++++++++++++ (new)
```

## Context

Part of the HMCTS APIM centralised Claude context system. Content is runtime behaviour only — no generated interface/model class names (those live in `api-cp-refdata-courthearing-courthouses`). Shared standards live in `apim-claude-template` and are live-imported via the developer-local `.claude/CLAUDE.md` (gitignored, **3 lines**):

```
@../../apim-claude-template/templates/shared-code-rules.md
@../../apim-claude-template/templates/service-shared.md
@../../apim-claude-template/templates/claude-md-standards.md
```

Set up with `/wire-claude-context`. The committed `CLAUDE.md` here contains only runtime behaviour unique to this service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)