### PR TITLE
feat: automated SIT deployment on GitHub release

### DIFF
--- a/.github/workflows/ci-build-publish.yml
+++ b/.github/workflows/ci-build-publish.yml
@@ -33,6 +33,14 @@ on:
       trigger_deploy:
         required: true
         type: boolean
+      deploy_dev:
+        required: false
+        type: boolean
+        default: true
+      deploy_sit:
+        required: false
+        type: boolean
+        default: false
       deploy_environment:
         required: false
         type: string
@@ -208,7 +216,7 @@ jobs:
 
   deploy-dev:
     needs: [Wait-For-ACR-Push, Artefact-Version, Build]
-    if: ${{ inputs.trigger_deploy }}
+    if: ${{ inputs.trigger_deploy && inputs.deploy_dev }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate date suffix
@@ -237,4 +245,37 @@ jobs:
               "cpbackendenv": "steccm64",
               "stack": "devamp01",
               "cluster": "K8-DEV-CS01-CL02"
+            }
+
+  deploy-sit:
+    needs: [Wait-For-ACR-Push, Artefact-Version, Build]
+    if: ${{ inputs.trigger_deploy && inputs.deploy_sit }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate date suffix
+        id: date
+        shell: bash
+        run: echo "suffix=_$(date -u +'%d%m%y')" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to SIT via ADO pipeline
+        uses: hmcts/action-ado-deploy@v1
+        with:
+          service_name: ${{ needs.Build.outputs.repo_name }}
+          image_tag: ${{ needs.Artefact-Version.outputs.artefact_version }}
+          tag_suffix: ${{ steps.date.outputs.suffix }}
+          app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+          app_private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+          target_repository: hmcts/cp-vp-aks-deploy
+          target_branch: env/sit
+          values_file: vp-config/services_values.yml
+          pipeline_id: 434
+          ado_pat: ${{ secrets.HMCTS_ADO_PAT }}
+          ref_name: refs/heads/env/sit
+          wait: false
+          template_parameters: >
+            {
+              "env": "sit",
+              "cpbackendenv": "sitccm01",
+              "stack": "sitamp01",
+              "cluster": "K8-SIT-CS01-CL02"
             }

--- a/.github/workflows/ci-released.yml
+++ b/.github/workflows/ci-released.yml
@@ -20,4 +20,6 @@ jobs:
       is_publish: true
       trigger_docker: true
       trigger_deploy: true
+      deploy_dev: false
+      deploy_sit: true
       deploy_environment: dev

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,142 @@
+# Release Design
+
+## Overview
+
+This document describes the release pipeline for `service-cp-refdata-courthearing-courthouses`. There are two separate deployment tracks — a continuous dev track triggered by every PR merge, and a deliberate release track triggered from the GitHub Releases UI. SIT deployment is fully automated once a release is published.
+
+---
+
+## Two tracks, two purposes
+
+| Track | Trigger | Environment | Version format | Example tag |
+|---|---|---|---|---|
+| **Dev CI** | PR merge to `main` | devamp01 | `{semver}-{githash}_{DDMMYY}` | `1.2.5-d54722d_290526` |
+| **Release** | GitHub Releases UI → publish | sitamp01 | `{semver}_{DDMMYY}` | `1.2.6_010626` |
+
+Dev gets every merged commit automatically. SIT only gets deliberate, tagged releases.
+
+---
+
+## Release flow
+
+```
+GitHub Releases UI
+    │
+    │  1. Navigate to:
+    │     https://github.com/hmcts/service-cp-refdata-courthearing-courthouses/releases/new
+    │  2. Type new tag in the tag field  e.g. v1.2.6
+    │  3. Click "Generate release notes"  (auto-fills PR titles as changelog)
+    │  4. Edit notes if needed, set title
+    │  5. Click "Publish release"
+    │
+    │  GitHub emits: release: published (checked out at tag v1.2.6)
+    │
+    ▼
+ci-released.yml
+    │   is_release:    true
+    │   deploy_dev:    false   ← dev is NOT touched by the release
+    │   deploy_sit:    true
+    │
+    ▼
+ci-build-publish.yml
+    ├── Artefact-Version  (artefact-version-action reads git tag v1.2.6 → "1.2.6")
+    ├── Build             service-cp-refdata-courthearing-courthouses-1.2.6.jar
+    ├── Build-Docker      ghcr.io/hmcts/service-cp-refdata-courthearing-courthouses:1.2.6
+    ├── Deploy            ADO pipeline 460: GHCR → ACR  tag: 1.2.6_010626
+    ├── Wait-For-ACR-Push
+    │
+    ├── deploy-dev        SKIPPED  (deploy_dev: false)
+    │
+    └── deploy-sit
+            writes cp-vp-aks-deploy / env/sit / vp-config/services_values.yml:
+              service-cp-refdata-courthearing-courthouses.image.tag = "1.2.6_010626"
+            triggers ADO pipeline 434 (ref: env/sit)
+            → deploys to sitamp01
+```
+
+---
+
+## Dev CI flow
+
+```
+PR merge to main
+    │
+    ▼
+ci-draft.yml
+    │   is_release:    false
+    │   deploy_dev:    true  (default)
+    │   deploy_sit:    false (default)
+    │
+    ▼
+ci-build-publish.yml
+    ├── Artefact-Version  (draft_version = "1.2.5-d54722d")
+    ├── Build
+    ├── Build-Docker      ghcr.io/...:1.2.5-d54722d
+    ├── Deploy            ADO pipeline 460 → ACR  tag: 1.2.5-d54722d_290526
+    ├── Wait-For-ACR-Push
+    │
+    ├── deploy-dev
+    │       writes env/dev services_values.yml: tag = "1.2.5-d54722d_290526"
+    │       triggers ADO pipeline 434 (ref: env/dev) → deploys to devamp01
+    │
+    └── deploy-sit        SKIPPED  (deploy_sit: false)
+
+    ── manual testing on devamp01 ──
+```
+
+---
+
+## Workflow inputs controlling the two tracks
+
+Defined in `ci-build-publish.yml`:
+
+| Input | Type | Default | Purpose |
+|---|---|---|---|
+| `is_release` | boolean | `false` | Switches version from `draft_version` (includes git hash) to `release_version` (clean semver from git tag) |
+| `trigger_deploy` | boolean | — | Gates ADO pipeline 460 (GHCR → ACR copy) and all deploy jobs |
+| `deploy_dev` | boolean | `true` | Controls `deploy-dev` job. Set to `false` in `ci-released.yml` so releases do not overwrite the dev environment |
+| `deploy_sit` | boolean | `false` | Controls `deploy-sit` job. Set to `true` in `ci-released.yml` |
+
+---
+
+## ACR tag format
+
+The date suffix (`_DDMMYY`) is appended by ADO pipeline 460 when it copies the image from GHCR to ACR. Our workflow reconstructs the same suffix at deploy time using `date -u +'%d%m%y'` so that `action-ado-deploy@v1` writes the correct matching tag to `services_values.yml`.
+
+| Build type | `artefact_version` | `tag_suffix` | Final ACR tag |
+|---|---|---|---|
+| Dev CI | `1.2.5-d54722d` | `_290526` | `1.2.5-d54722d_290526` |
+| Release | `1.2.6` | `_010626` | `1.2.6_010626` |
+
+---
+
+## Environment promotion after SIT
+
+SIT receives automatic deployment on every release. Promotion from SIT to PRP and PRD is a separate batch operation managed in `cp-vp-aks-deploy`:
+
+- **SIT → PRP**: `promote-environment.yml` (`workflow_dispatch`, source: `sit`, target: `prp`)
+- **PRP → PRD**: `promote-environment.yml` (`workflow_dispatch`, source: `prp`, target: `prd`) — creates a PR requiring change approval
+- Release cycle name (e.g. `rel_amp_2607`) is the PR title used when promoting to PRD
+
+---
+
+## How to create a release (step by step)
+
+1. Open the Releases page for this repo:
+   `https://github.com/hmcts/service-cp-refdata-courthearing-courthouses/releases/new`
+
+2. In **"Choose a tag"**, type the next version and select **"Create new tag on publish"**
+   - Patch bump (bug fixes): `v1.2.5` → `v1.2.6`
+   - Minor bump (new features): `v1.2.5` → `v1.3.0`
+   - Major bump (breaking change): `v1.2.5` → `v2.0.0`
+
+3. Set the release title to match the tag, e.g. `v1.2.6`
+
+4. Click **"Generate release notes"** — GitHub auto-fills the changelog from PR titles merged since the last tag
+
+5. Review and edit the notes if needed
+
+6. Click **"Publish release"**
+
+The SIT deployment starts automatically — no further action needed. Track progress at:
+`https://github.com/hmcts/service-cp-refdata-courthearing-courthouses/actions`


### PR DESCRIPTION
## Background

This is the same change applied to `service-cp-caseadmin-case-urn-mapper` (PR #181). It wires automated SIT deployment so that publishing a GitHub release triggers deployment to `sitamp01` without any manual steps.

## What changed

**`ci-build-publish.yml`**
- Added `deploy_dev` input (boolean, default: `true`) — gates the `deploy-dev` job
- Added `deploy_sit` input (boolean, default: `false`) — gates the new `deploy-sit` job
- Updated `deploy-dev` condition: `trigger_deploy && deploy_dev`
- Added `deploy-sit` job: runs after `Wait-For-ACR-Push`, writes ACR tag to `env/sit` in `cp-vp-aks-deploy`, triggers ADO pipeline 434

**`ci-released.yml`**
- Added `deploy_dev: false` — release does not overwrite dev
- Added `deploy_sit: true` — release auto-deploys to SIT

**`docs/release.md`** — new file documenting the two-track release design and step-by-step instructions for creating a GitHub release

## How it works after merge

1. Developer merges PR → dev gets deployed automatically (unchanged behaviour)
2. When ready to release: GitHub Releases UI → publish tag → SIT deploys automatically, dev untouched

🤖 Generated with [Claude Code](https://claude.ai/claude-code)