### PR TITLE
fix: update dev cpbackendenv from steccm64 to steccm14

### DIFF
--- a/.github/workflows/ci-build-publish.yml
+++ b/.github/workflows/ci-build-publish.yml
@@ -242,7 +242,7 @@ jobs:
           template_parameters: >
             {
               "env": "dev",
-              "cpbackendenv": "steccm64",
+              "cpbackendenv": "steccm14",
               "stack": "devamp01",
               "cluster": "K8-DEV-CS01-CL02"
             }


### PR DESCRIPTION
## Summary
- Updates \`cpbackendenv\` in the \`deploy-dev\` job from \`steccm64\` to \`steccm14\`
- SIT (\`sitccm01\`) is unchanged

## Test plan
- [ ] Verify only the dev block changed (line 245)
- [ ] Trigger a dev deploy after merge to confirm the correct backend env is targeted